### PR TITLE
Mask out a part of the channels when applying attention (idea of mr Francis)

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -9,7 +9,7 @@ class GPTConfig(eqx.Module):
     n_layers: int = 6
     n_heads: int = 6
     n_embed: int = 384
-    dropout: float = 0.1
+    dropout: float = 0.2
     dtype: jnp.dtype = jnp.float32
 
     @classmethod

--- a/configs.py
+++ b/configs.py
@@ -55,7 +55,7 @@ class TrainConfig(eqx.Module):
             case "gpt2":
                 return TrainConfig(
                     batch_size=256,  # gpt2 paper - 512
-                    n_grad_accumulation=1,
+                    n_grad_accumulation=2,
                     train_for=600_000,
                     weight_decay=1e-1,
                     lr_config={

--- a/model.py
+++ b/model.py
@@ -39,7 +39,7 @@ class Block(eqx.Module):
         )
         self.dropout = eqx.nn.Dropout(config.dropout)
         self.config = config
-        self.zero = jr.normal(k3, (config.context_len, config.n_embed), dtype=config.dtype)
+        self.zero = jr.normal(k3, (config.n_embed,), dtype=config.dtype) * 0.02
 
     def __call__(
         self, x: Float[Array, "ctx emb"], key: PRNGKeyArray | None = None
@@ -56,7 +56,8 @@ class Block(eqx.Module):
             jnp.arange(self.config.n_embed) < int(self.config.n_embed * 0.05),
             (self.config.context_len, 1),
         )  # shape: (256, 384)
-        x = jnp.where(free_mask, self.zero, x) + self.attn(
+        zero_value = jnp.tile(self.zero, (self.config.context_len, 1))
+        x = jnp.where(free_mask, zero_value, x) + self.attn(
             query=x_normed,
             key_=x_normed,
             value=x_normed,

--- a/model.py
+++ b/model.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import einops
 import equinox as eqx
+import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -48,7 +49,12 @@ class Block(eqx.Module):
 
         x_normed = eqx.filter_vmap(self.lnorm_attn)(x).astype(x.dtype)
         x_normed = jnp.nan_to_num(x_normed)  # make sure the softmax is well defined
-        x = x + self.attn(
+
+        free_mask = jnp.tile(
+            jnp.arange(self.config.n_embed) < int(self.config.n_embed * 0.5),
+            (self.config.context_len, 1),
+        )  # shape: (256, 384)
+        x = jnp.where(free_mask, jnp.zeros_like(x), x) + self.attn(
             query=x_normed,
             key_=x_normed,
             value=x_normed,
@@ -139,8 +145,22 @@ class GPT(eqx.Module):
             x = x.at[input_len:].set(jnp.nan)  # mask out padding
 
             key = jr.PRNGKey(0) if key is None else key
-            for block, bkey in zip(self.blocks, jr.split(key, len(self.blocks))):
-                x = block(x, key=bkey)
+            blocks_dynamic = eqx.filter(self.blocks, eqx.is_array)
+            blocks_dynamic = jax.tree.map(
+                lambda *b: jnp.stack(b) if b[0] is not None else None,
+                *blocks_dynamic,
+                is_leaf=eqx.is_array,
+            )
+            block_static = eqx.filter(self.blocks[0], lambda x: not eqx.is_array(x))
+
+            def scan_fn(carry, inputs):
+                block_dyn, bkey = inputs
+                block = eqx.combine(block_dyn, block_static)
+                return block(carry, key=bkey), None
+
+            x, _ = eqxi.scan(
+                scan_fn, x, (blocks_dynamic, jr.split(key, len(self.blocks))), kind="lax"
+            )
             x = eqx.filter_vmap(self.final_norm)(x).astype(x.dtype)
 
             if targets is not None:

--- a/model.py
+++ b/model.py
@@ -54,8 +54,7 @@ class Block(eqx.Module):
             jnp.arange(self.config.n_embed) < int(self.config.n_embed * 0.1),
             (self.config.context_len, 1),
         )  # shape: (256, 384)
-        zero_value = jnp.tile(0.0, (self.config.context_len, 1))
-        x = jnp.where(free_mask, zero_value, x) + self.attn(
+        x = jnp.where(free_mask, 0.0, x) + self.attn(
             query=x_normed,
             key_=x_normed,
             value=x_normed,


### PR DESCRIPTION
The point is to make an "attention only" part of the residual: e.g. a way for a residual of the previous layer modify attention of the next layer, but without affecting the actual residual.